### PR TITLE
[#275] : joyride 추가 수정 (외근 요청) 및 직원페이지 달력 범례 수정

### DIFF
--- a/src/Components/company/EmployeeListBox.tsx
+++ b/src/Components/company/EmployeeListBox.tsx
@@ -87,7 +87,7 @@ const EmployeeListBox = () => {
   }, [api]);
 
   return (
-    <div className="space-y-4" data-tour="manager_home-4">
+    <div className="space-y-4" data-tour="manager_home-5">
       <SummaryCard title="전체 구성원 수" count={employeeList.length} icon={Users} />
 
       <div className="hidden h-[28rem] grid-cols-1 gap-5 md:grid md:grid-cols-2">

--- a/src/Components/company/ManagerVacationBox.tsx
+++ b/src/Components/company/ManagerVacationBox.tsx
@@ -50,7 +50,7 @@ const VacationRequestBox = () => {
   );
 
   return (
-    <div className="flex flex-col gap-4" data-tour="manager_home-3">
+    <div className="flex flex-col gap-4" data-tour="manager_home-4">
       {/* 요청 목록 */}
       <SummaryCard
         title="처리되지 않은 휴가 요청 목록"

--- a/src/Components/company/TodayCommuteBox.tsx
+++ b/src/Components/company/TodayCommuteBox.tsx
@@ -175,7 +175,7 @@ export const TodayCommuteBox = () => {
         </div>
       </div>
 
-      <div className="flex w-full flex-col gap-4 md:flex-row">
+      <div className="flex w-full flex-col gap-4 md:flex-row" data-tour="manager_home-3">
         {[
           { title: "현재 근무 중", list: workingEmployees },
           { title: "금일 외근", list: outworkingEmployees },
@@ -204,7 +204,10 @@ export const TodayCommuteBox = () => {
             </div>
 
             {/* 리스트 */}
-            <ul className="relative max-h-[480px] space-y-3 overflow-y-auto pr-1 pt-5">
+            <ul
+              className="relative max-h-[480px] space-y-3 overflow-y-auto pr-1 pt-5"
+              data-tour="manager_home-2"
+            >
               {/* 외근 요청 알림 (오른쪽 아이콘 + 텍스트) */}
 
               {list?.length > 0 ? (

--- a/src/Components/company/WorkplaceBox.tsx
+++ b/src/Components/company/WorkplaceBox.tsx
@@ -8,7 +8,7 @@ import { ScrollArea } from "../ui/scroll-area";
 const WorkplaceBox = () => {
   const workPlaces = useCompanyStore(state => state.currentCompany?.workPlacesList);
   return (
-    <div className="space-y-4" data-tour="manager_home-5">
+    <div className="space-y-4" data-tour="manager_home-6">
       <SummaryCard title="전체 근무지 수" count={workPlaces?.length} icon={Building2} />
 
       <CardContent className="flex h-[28rem] items-center justify-center rounded-xl p-2 shadow-md">

--- a/src/Components/company/attendance/DaliyAttendanceUI.tsx
+++ b/src/Components/company/attendance/DaliyAttendanceUI.tsx
@@ -338,7 +338,7 @@ export const FullAttendanceRatioChart = ({ selectedDate }: { selectedDate: Date 
           <span className="text-sm text-point-color">{dayjs(selectedDate).format("M월 D일")}</span>
         </div>
 
-        <div className="relative h-48 w-full sm:h-64 md:h-72">
+        <div className="relative h-48 w-full sm:h-64 md:h-72" data-tour="today-6">
           <ResponsiveContainer width="100%" height="100%">
             <RechartPieChart>
               <Pie
@@ -400,7 +400,7 @@ export const OutworkingBox = ({ selectedDate }: { selectedDate: Date }) => {
   return (
     <div
       className="dark:border-outwork-color-dark dark:bg-outwork-color-dark flex flex-1 flex-col gap-4 rounded-xl bg-white p-4 shadow-lg"
-      data-tour="today-6"
+      data-tour="today-7"
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-base font-bold text-gray-800 dark:text-white sm:text-lg">
@@ -464,7 +464,7 @@ export const WorkplaceBreakdown = ({ selectedDate }: { selectedDate: Date }) => 
   const { companyCode } = useParams();
 
   return (
-    <Card className="w-full bg-white" data-tour="today-7">
+    <Card className="w-full bg-white" data-tour="today-8">
       <CardContent className="p-4">
         <div>
           <div className="flex items-center gap-2 text-lg font-bold text-zinc-800 dark:text-white sm:text-xl">

--- a/src/constants/managerTourSteps.ts
+++ b/src/constants/managerTourSteps.ts
@@ -155,12 +155,17 @@ export const todayAttSteps: Step[] = [
   },
   {
     target: '[data-tour="today-6"]',
+    content: "특정 그래프를 클릭하시면 해당 근무지에 대한 직원 정보를 보실 수 있습니다.",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="today-7"]',
     content:
       "금일 외근 요청을 통해 승인/거절 처리가 가능하고, 처리된 직원들의 상세 정보를 볼 수 있습니다.",
     disableBeacon: true,
   },
   {
-    target: '[data-tour="today-7"]',
+    target: '[data-tour="today-8"]',
     content: "금일 근무지별 출근한 직원들의 상세 정보를 볼 수 있습니다.",
     disableBeacon: true,
   },

--- a/src/constants/managerTourSteps.ts
+++ b/src/constants/managerTourSteps.ts
@@ -15,7 +15,7 @@ export const noticeTourSteps: Step[] = [
     target: '[data-tour="notice-3"]', // NoticeCard 전체
     content:
       "등록된 공지사항을 확인할 수 있어요. 자세한 내용을 보시고 싶으시면 박스를 클릭하시면 됩니다.",
-    placement: "top",
+    placement: "bottom",
   },
 ];
 
@@ -155,7 +155,8 @@ export const todayAttSteps: Step[] = [
   },
   {
     target: '[data-tour="today-6"]',
-    content: "금일 외근 처리한 직원들의 상세 정보를 볼 수 있습니다.",
+    content:
+      "금일 외근 요청을 통해 승인/거절 처리가 가능하고, 처리된 직원들의 상세 정보를 볼 수 있습니다.",
     disableBeacon: true,
   },
   {
@@ -180,8 +181,7 @@ export const homeSteps: Step[] = [
   {
     target: '[data-tour="manager_home-2"]',
     disableScrolling: false,
-    content:
-      "금일 출퇴근 정보를 한눈에 볼 수 있는 박스입니다. 클릭하셔서 상세페이지로 이동할 수 있습니다.",
+    content: "금일 출퇴근 정보를 한눈에 볼 수 있는 박스입니다. 외근 처리도 여기서 가능합니다.",
     disableBeacon: true,
   },
   {

--- a/src/constants/managerTourSteps.ts
+++ b/src/constants/managerTourSteps.ts
@@ -12,7 +12,7 @@ export const noticeTourSteps: Step[] = [
     placement: "bottom",
   },
   {
-    target: '[data-tour="notice-3"]', // NoticeCard 전체
+    target: '[data-tour="notice-3"]',
     content:
       "등록된 공지사항을 확인할 수 있어요. 자세한 내용을 보시고 싶으시면 박스를 클릭하시면 됩니다.",
     placement: "bottom",
@@ -192,19 +192,25 @@ export const homeSteps: Step[] = [
   {
     target: '[data-tour="manager_home-3"]',
     disableScrolling: false,
+    content: "이 곳에서 직원의 전화번호 복사 기능과 외근 요청 처리도 가능합니다.",
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="manager_home-4"]',
+    disableScrolling: false,
     content: "직원의 휴가 요청 및 이번달 직원들의 전체 휴가 내역을 한눈에 볼 수 있는 박스입니다.",
     disableBeacon: true,
     placement: "bottom",
   },
   {
-    target: '[data-tour="manager_home-4"]',
+    target: '[data-tour="manager_home-5"]',
     disableScrolling: false,
     content: "회사의 설정된 직무를 볼 수 있는 박스입니다.",
     disableBeacon: true,
     placement: "top",
   },
   {
-    target: '[data-tour="manager_home-5"]',
+    target: '[data-tour="manager_home-6"]',
     disableScrolling: false,
     content: "회사의 설정된 근무지를 볼 수 있는 박스입니다.",
     disableBeacon: true,

--- a/src/pages/manager/NoticePage.tsx
+++ b/src/pages/manager/NoticePage.tsx
@@ -99,13 +99,13 @@ const NoticePage = () => {
           )}
         </div>
 
-        <div className="grid w-full max-w-7xl grid-cols-1 gap-4 px-4 sm:px-6 md:grid-cols-2">
+        <div
+          className="grid w-full max-w-7xl grid-cols-1 gap-4 px-4 sm:px-6 md:grid-cols-2"
+          data-tour="notice-3"
+        >
           {sortedNotices.length === 0 ? (
             <>
-              <div
-                data-tour="notice-3"
-                className="flex h-24 items-center justify-center rounded-md border border-dashed border-gray-300 bg-gray-50 text-sm text-gray-400"
-              >
+              <div className="flex h-24 items-center justify-center rounded-md border border-dashed border-gray-300 bg-gray-50 text-sm text-gray-400">
                 등록된 공지사항이 없습니다.
               </div>
             </>

--- a/src/util/commute.util.ts
+++ b/src/util/commute.util.ts
@@ -3,8 +3,8 @@ import dayjs from "dayjs";
 
 export const getWorkTypeFromCommute = (data?: TCommuteData): "출근" | "외근" | undefined => {
   if (!data) return undefined;
-  if (data.startTime) return "출근";
   if (data.outworkingMemo || data.startWorkplaceId === "외근") return "외근";
+  if (data.startTime) return "출근";
   return undefined;
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #275 

## 📝작업 내용

> joyride 추가 및 텍스트 수정
- 그래프 상세 모달을 위한 가이드 추가
![스크린샷 2025-06-12 오후 4 58 55](https://github.com/user-attachments/assets/b3aaee32-fa3a-41ad-880a-61eca85eaf1b)

- 외근 요청 관련 텍스트 수정
- 기존 가이드 스텝들에 외근 관련들을 넣었습니다. 외근 요청 모달에도 스텝을 넣으려고 했으나, 제어방식(모달) 부분은 오래 걸리는 작업이고 다른 페이지에도 제어방식을 제거했기 때문에 리팩토링 기간에 적용할 생각입니다.

> 직원 출퇴근 기록 페이지 달력 부분 범례 수정
- 외근 요청 그리고 외근 출근 시간이 추가면서 외근에도 관여되는 startTime 때문에 외근을 찍어도 출근 상태로 나오는 현상을 수정했습니다.
- startTime 유무를 체크하는 코드를 후순위로 배치하면서 외근과 출근 구별을 명확히 하였습니다.
```tsx
export const getWorkTypeFromCommute = (data?: TCommuteData): "출근" | "외근" | undefined => {
  if (!data) return undefined;
  if (data.outworkingMemo || data.startWorkplaceId === "외근") return "외근";
  if (data.startTime) return "출근";
  return undefined;
}; 
```


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
