### PR TITLE
[#287] : 로그인/회원가입 페이지 폼 문구 추가

### DIFF
--- a/src/Components/auth/EmployeeCompanyForm.tsx
+++ b/src/Components/auth/EmployeeCompanyForm.tsx
@@ -21,7 +21,7 @@ export const EmployeeCompanyForm = ({
 }: IEmployeeCompanyFormProps) => {
   return (
     <div className="space-y-4">
-      <h4 className="text-black font-medium">가입 회사 정보</h4>
+      <h4 className="font-medium text-black">가입 회사 정보</h4>
 
       <div className="space-y-4">
         {!isCodeValid ? (
@@ -62,6 +62,7 @@ export const EmployeeCompanyForm = ({
         >
           회사찾기
         </Button>
+        <p className="text-xs">※ 올바른 회사코드 입력 후 버튼을 누르면 적용됩니다.</p>
       </div>
     </div>
   );

--- a/src/Components/auth/LoginForm.tsx
+++ b/src/Components/auth/LoginForm.tsx
@@ -29,6 +29,7 @@ const LoginForm = ({ emailRef, passwordRef }: ILoginFormProps) => {
           aria-describedby="password-error"
           className="px-3"
         />
+        <p className="text-xs">※ 비밀번호 분실 시 관리자에게 문의하세요.</p>
       </div>
     </div>
   );

--- a/src/Components/auth/PersonalInfoForm.tsx
+++ b/src/Components/auth/PersonalInfoForm.tsx
@@ -19,7 +19,7 @@ export const PersonalInfoForm = ({ form }: IPersonalInfoFormProps) => {
 
   return (
     <div className="space-y-4">
-      <h4 className="text-black font-medium">개인 정보</h4>
+      <h4 className="font-medium text-black">개인 정보</h4>
 
       <FormField
         control={form.control}
@@ -49,6 +49,7 @@ export const PersonalInfoForm = ({ form }: IPersonalInfoFormProps) => {
                 placeholder="예) hongildong@naver.com"
               />
             </FormControl>
+            <p className="text-xs">※유효한 이메일을 입력하세요.</p>
             <FormMessage />
           </FormItem>
         )}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #287 

## 📝작업 내용

> 로그인/회원가입 페이지 폼 문구 추가

- 회원가입
![스크린샷 2025-06-17 오후 10 33 17](https://github.com/user-attachments/assets/3f3ab6ae-41d8-4d12-b8f1-b52736c7c4b5)
![스크린샷 2025-06-17 오후 10 38 06](https://github.com/user-attachments/assets/93462667-10ea-49a1-98a4-1a77fd4b84f0)

- 로그인
![스크린샷 2025-06-17 오후 10 38 29](https://github.com/user-attachments/assets/caf7af66-14dd-4eba-a110-1babfe37893e)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
